### PR TITLE
Remove rake task which checks portability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,18 +5,3 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
-namespace(:spec) do
-  desc "Run all specs on multiple ruby versions (requires rvm)"
-  task(:portability) do
-    %w[1.8.7 1.9.2].each do |version|
-      system <<-BASH
-bash -c 'source ~/.rvm/scripts/rvm;
-rvm #{version};
-echo "--------- version #{version} ----------\n";
-bundle install;
-rake spec'
-BASH
-    end
-  end
-end
-


### PR DESCRIPTION
While `guard-migrate` uses Travis-CI there is no need for keeping that rake task (as it's even not updated for last 3 years)
