### PR TITLE
Allow command to be run without "bundle exec"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,6 +29,7 @@ Add guard definition to your Guardfile by running this command:
 Available options:
 
 * :cmd - this will specify a custom command to run, you can use it to speed up migrations if you use `zeus`, `spring` or simillar in your project. Defaults to `rake`
+* :bundler - this will prefix the command with `bundle exec` if a Gemfile is present. Defaults to `true`
 * :run_on_start - this will run the migration task when you start, reload or run all. Defaults to false. If reset is set to true with this, then it will run a reset on the start, reload, run all instead of just a regular migrate
 * :test_clone - this will run the with the additional `db:test:clone` to update the test database. Defaults to true.
 * :reset - this will run `rake db:migrate:reset` every time migrate is run. Defaults to false.

--- a/lib/guard/migrate.rb
+++ b/lib/guard/migrate.rb
@@ -10,6 +10,7 @@ module Guard
     def initialize(watchers=[], options={})
       super
 
+      @bundler = true unless options[:bundler] == false
       @cmd = options[:cmd].to_s unless options[:cmd].to_s.empty?
       @reset = true if options[:reset] == true
       @test_clone = true unless options[:test_clone] == false
@@ -19,7 +20,7 @@ module Guard
     end
 
     def bundler?
-      @bundler ||= File.exist?("#{Dir.pwd}/Gemfile")
+      !!@bundler && File.exist?("#{Dir.pwd}/Gemfile")
     end
 
     def run_on_start?

--- a/spec/guard/migrate_spec.rb
+++ b/spec/guard/migrate_spec.rb
@@ -22,6 +22,12 @@ describe Guard::Migrate do
         its(:bundler?){should be_true}
         its(:rake_string){should match(/^bundle exec rake/)}
 
+        context "with bunder set to false" do
+          let(:options){ { :bundler => false }}
+
+          its(:bundler?){should be_false}
+          its(:rake_string){should match(/^rake/)}
+        end
       end
       context "with no gemfile found" do
         before{File.stub!(:exist?).and_return(false)}


### PR DESCRIPTION
Rails 4.1 includes spring which runs faster if "bundle exec" is not
prefixed to the command.
