### PR TITLE
WARNING: db:test:clone is deprecated.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,7 +31,7 @@ Available options:
 * :cmd - this will specify a custom command to run, you can use it to speed up migrations if you use `zeus`, `spring` or simillar in your project. Defaults to `rake`
 * :bundler - this will prefix the command with `bundle exec` if a Gemfile is present. Defaults to `true`
 * :run_on_start - this will run the migration task when you start, reload or run all. Defaults to false. If reset is set to true with this, then it will run a reset on the start, reload, run all instead of just a regular migrate
-* :test_clone - this will run the with the additional `db:test:clone` to update the test database. Defaults to true.
+* :test_clone - this will run the with the additional `db:test:clone` to update the test database. Defaults to false.
 * :reset - this will run `rake db:migrate:reset` every time migrate is run. Defaults to false.
 * :rails_env - passing this will add "RAILS_ENV=" together with the environment.
 * :seed - setting this option to true will run seed after migrations. This will also run after test:clone if that is set to run. Defaults to false.

--- a/lib/guard/migrate.rb
+++ b/lib/guard/migrate.rb
@@ -13,7 +13,7 @@ module Guard
       @bundler = true unless options[:bundler] == false
       @cmd = options[:cmd].to_s unless options[:cmd].to_s.empty?
       @reset = true if options[:reset] == true
-      @test_clone = true unless options[:test_clone] == false
+      @test_clone = options[:test_clone]
       @run_on_start = true if options[:run_on_start] == true
       @rails_env = options[:rails_env]
       @seed = options[:seed]

--- a/spec/guard/migrate_spec.rb
+++ b/spec/guard/migrate_spec.rb
@@ -88,15 +88,23 @@ describe Guard::Migrate do
 
     context "test clone" do
       context "with no options passed" do
-        its(:test_clone?){should be_true}
-        its(:rake_string){should match(/db:test:clone/)}
+        its(:test_clone?){should be_false}
+        its(:rake_string){should match(/rake db:migrate/)}
+        its(:rake_string){should_not match(/db:test:clone/)}
       end
 
       context "when passed false" do
         let(:options){ {:test_clone => false} }
-        its(:test_clone?){should_not be_true}
+        its(:test_clone?){should be_false}
         its(:rake_string){should match(/rake db:migrate/)}
         its(:rake_string){should_not match(/db:test:clone/)}
+      end
+
+      context "when passed true" do
+        let(:options){ {:test_clone => true} }
+        its(:test_clone?){should be_true}
+        its(:rake_string){should match(/rake db:migrate/)}
+        its(:rake_string){should match(/db:test:clone/)}
       end
     end
 


### PR DESCRIPTION
I generated a new Rails 4.1 app, with guard-migrate version 1.0.4.  Once I add a migration, I get the following warning:

```
WARNING: db:test:clone is deprecated. The Rails test helper now maintains your test schema automatically, see the release notes for details.
```

Modifying my guard file to read:

```
guard :migrate, test_clone: false do
```

Makes the warning go away.

I'd suggest that for Rails 4.1+ the test_clone option be defaulted to false.

Questions:
1)  Do you agree?

2)  I attempted to fix it (see commit), but it looks like Rails is not loaded at the time this code is run.  The following could work, but it seems heavy...

```
Gem::Version.new(`rails version`.gsub(/[^.\d]/, '')) <= Gem::Version.new("4.1.0")
```

3)  Should I modify the tests (spec/guard/migrate_spec.rb:89) for this change?  Are those the right tests to modify?  

4) Another possibility would  be changing the default value to false for version 1.1.0.
