### PR TITLE
Replace test_clone option with test_prepare

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,10 +33,10 @@ Available options:
 * :cmd - this will specify a custom command to run, you can use it to speed up migrations if you use `zeus`, `spring` or simillar in your project. Defaults to `rake`
 * :bundler - this will prefix the command with `bundle exec` if a Gemfile is present. Defaults to `true`
 * :run_on_start - this will run the migration task when you start, reload or run all. Defaults to false. If reset is set to true with this, then it will run a reset on the start, reload, run all instead of just a regular migrate
-* :test_clone - this will run the with the additional `db:test:clone` to update the test database. Defaults to false.
+* :test_prepare - this will run the with the additional `db:test:prepare` to update the test database. Defaults to false.
 * :reset - this will run `rake db:migrate:reset` every time migrate is run. Defaults to false.
 * :rails_env - passing this will add "RAILS_ENV=" together with the environment.
-* :seed - setting this option to true will run seed after migrations. This will also run after test:clone if that is set to run. Defaults to false.
+* :seed - setting this option to true will run seed after migrations. This will also run after test:prepare if that is set to run. Defaults to false.
 
 == Todos
 

--- a/lib/guard/migrate.rb
+++ b/lib/guard/migrate.rb
@@ -12,7 +12,7 @@ module Guard
       @bundler = true unless options[:bundler] == false
       @cmd = options[:cmd].to_s unless options[:cmd].to_s.empty?
       @reset = true if options[:reset] == true
-      @test_clone = options[:test_clone]
+      @test_prepare = options[:test_prepare]
       @run_on_start = true if options[:run_on_start] == true
       @rails_env = options[:rails_env]
       @seed = options[:seed]
@@ -30,8 +30,8 @@ module Guard
       !!@cmd
     end
 
-    def test_clone?
-      !!@test_clone
+    def test_prepare?
+      !!@test_prepare
     end
 
     def reset?
@@ -109,7 +109,7 @@ module Guard
         rake_command,
         migrate_string(version),
         seed_string,
-        clone_string,
+        prepare_string,
         rails_env_string
       ].compact.join(' ')
     end
@@ -120,7 +120,7 @@ module Guard
         custom_command,
         rake_command,
         seed_string,
-        clone_string,
+        prepare_string,
         rails_env_string
       ].compact.join(' ')
     end
@@ -158,9 +158,9 @@ module Guard
       "RAILS_ENV=#{rails_env}" if rails_env
     end
 
-    def clone_string
-      return if !test_clone? || custom_command.to_s.match(/db:test:clone/)
-      'db:test:clone'
+    def prepare_string
+      return if !test_prepare? || custom_command.to_s.match(/db:test:prepare/)
+      'db:test:prepare'
     end
 
     def seed_string

--- a/spec/guard/migrate_spec.rb
+++ b/spec/guard/migrate_spec.rb
@@ -113,12 +113,12 @@ RSpec.describe Guard::Migrate do
             end
           end
 
-          context 'with duplication of db:test:clone' do
-            let(:options) { { cmd: 'custom command rake db:test:clone' } }
+          context 'with duplication of db:test:prepare' do
+            let(:options) { { cmd: 'custom command rake db:test:prepare' } }
 
             context 'rake_string' do
-              it "should contains 'db:test:clone' once" do
-                expect(subject.rake_string.scan('db:test:clone').size).to eq(1)
+              it "should contains 'db:test:prepare' once" do
+                expect(subject.rake_string.scan('db:test:prepare').size).to eq(1)
               end
             end
           end
@@ -126,10 +126,10 @@ RSpec.describe Guard::Migrate do
       end
     end
 
-    context 'test clone' do
+    context 'test prepare' do
       context 'with no options passed' do
-        describe '#test_clone?' do
-          subject { super().test_clone? }
+        describe '#test_prepare?' do
+          subject { super().test_prepare? }
           it { is_expected.to be_falsey }
         end
 
@@ -140,15 +140,15 @@ RSpec.describe Guard::Migrate do
 
         describe '#rake_string' do
           subject { super().rake_string }
-          it { is_expected.not_to match(/db:test:clone/) }
+          it { is_expected.not_to match(/db:test:prepare/) }
         end
       end
 
       context 'when passed false' do
-        let(:options) { { test_clone: false } }
+        let(:options) { { test_prepare: false } }
 
-        describe '#test_clone?' do
-          subject { super().test_clone? }
+        describe '#test_prepare?' do
+          subject { super().test_prepare? }
           it { is_expected.to be_falsey }
         end
 
@@ -159,15 +159,15 @@ RSpec.describe Guard::Migrate do
 
         describe '#rake_string' do
           subject { super().rake_string }
-          it { is_expected.not_to match(/db:test:clone/) }
+          it { is_expected.not_to match(/db:test:prepare/) }
         end
       end
 
       context 'when passed true' do
-        let(:options) { { test_clone: true } }
+        let(:options) { { test_prepare: true } }
 
-        describe '#test_clone?' do
-          subject { super().test_clone? }
+        describe '#test_prepare?' do
+          subject { super().test_prepare? }
           it { is_expected.to be_truthy }
         end
 
@@ -178,7 +178,7 @@ RSpec.describe Guard::Migrate do
 
         describe '#rake_string' do
           subject { super().rake_string }
-          it { is_expected.to match(/db:test:clone/) }
+          it { is_expected.to match(/db:test:prepare/) }
         end
       end
     end
@@ -322,21 +322,21 @@ RSpec.describe Guard::Migrate do
         end
       end
 
-      context 'when seed is set to true and clone is set to true' do
-        let(:options) { { seed: true, test_clone: true } }
-        it 'runs the seed option before the clone option' do
-          expect(subject.rake_string).to match(/db:seed.*db:test:clone/)
+      context 'when seed is set to true and prepare is set to true' do
+        let(:options) { { seed: true, test_prepare: true } }
+        it 'runs the seed option before the prepare option' do
+          expect(subject.rake_string).to match(/db:seed.*db:test:prepare/)
         end
       end
     end
 
     context 'when the seeds file is passed as the paths' do
       let(:paths) { ['db/seeds.rb'] }
-      let(:options) { { seed: true, test_clone: true } }
+      let(:options) { { seed: true, test_prepare: true } }
 
       describe '#seed_only_string' do
         subject { super().seed_only_string }
-        it { is_expected.to match(/db:seed db:test:clone/) }
+        it { is_expected.to match(/db:seed db:test:prepare/) }
       end
 
       it 'runs the rake command with seed only' do
@@ -375,7 +375,7 @@ RSpec.describe Guard::Migrate do
 
   context 'run on change when set to reset should only run migrations one time' do
     let(:paths) { [create_valid_up_and_down_migration('1234_i_like_cheese').path, create_valid_change_migration('1235_i_like_cheese').path] }
-    let(:options) { { reset: true, test_clone: true } }
+    let(:options) { { reset: true, test_prepare: true } }
     it 'should run the rake command' do
       expect(subject).to receive(:system).with(subject.rake_string('1234'))
       allow(Guard::Compat::UI).to receive(:info)


### PR DESCRIPTION
db:test:clone is deprecated because Rails is now supposed to handle that automatically.

However, it doesn't handle redos, because it just compares schema and migration timestamps. db:test:prepare, however, does handle this case, is (no longer) deprecated, and is explicitly present in Rails for this use-case: rails/rails#17739.

***

I suspect you'll want to handle this some other way than replacing `test_clone`, but I think some way to automatically run `db:test:prepare` is definitely needed.